### PR TITLE
Fix deprecated reference to setTitle in Controllers documentation

### DIFF
--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -82,7 +82,7 @@ class InvoicesController extends Controller
 {
     public function initialize()
     {
-        $this->tag->setTitle('Invoices Management');
+        $this->tag->title()->set('Invoices Management');
     }
 
     public function listAction(int $page = 1, int $perPage = 25)


### PR DESCRIPTION
Phalcon\Tag are legacy and no longer exist in the current phalcon version.