### PR TITLE
Update documentation links and add a warning for relation delete() callback

### DIFF
--- a/docs/autoload.md
+++ b/docs/autoload.md
@@ -746,3 +746,4 @@ Unregister the autoload method
 [loader]: api/phalcon_autoload.md#autoloadloader
 [loader-exception]: api/phalcon_autoload.md#autoloadexception
 [eventsawareinterface]: api/phalcon_events.md#eventseventsawareinterface
+[events]: api/phalcon_events.md#eventsmanager

--- a/docs/config.md
+++ b/docs/config.md
@@ -870,3 +870,4 @@ Also in views (Volt syntax)
 [parse-ini-file]: https://www.php.net/manual/en/function.parse-ini-file.php
 [yaml-parse-file]: https://www.php.net/manual/en/function.yaml-parse-file.php
 [di]: di.md
+[support-collection]: support-collection.md

--- a/docs/controllers.md
+++ b/docs/controllers.md
@@ -625,3 +625,5 @@ $container->set(
 [events]: events.md
 [application]: application.md
 [autoload]: autoload.md
+[routing]: routing.md
+[views]: views.md

--- a/docs/db-models-relationships.md
+++ b/docs/db-models-relationships.md
@@ -1398,6 +1398,19 @@ $customer->getInvoices()->delete();
 
 `delete()` also accepts an anonymous function to filter what records must be deleted:
 
+!!! warning "NOTE"
+
+    `delete()` only works safely with `hasMany()` relationships. The deletion callback runs before the actual deletion of the parent model.
+    
+    This makes it safe for:
+    
+    - Deleting child models that hold a foreign key to the parent (e.g., hasMany)
+    
+    But unsafe for:
+    
+    - Deleting related models that the parent depends on via a foreign key (e.g., belongsTo or hasOne where FK is in parent)
+
+
 ```php
 <?php
 

--- a/docs/di.md
+++ b/docs/di.md
@@ -1604,6 +1604,7 @@ The [Phalcon\Di\DiInterface][di-diinterface] interface must be implemented to cr
 [annotations]: annotations.md
 [ssets]: ssets.md
 [encryption-crypt]: encryption-crypt.md
+[assets]: assets.md
 [response-cookies]: response.md#cookies
 [dispatcher]: dispatcher.md
 [html-escaper]: html-escaper.md
@@ -1621,4 +1622,5 @@ The [Phalcon\Di\DiInterface][di-diinterface] interface must be implemented to cr
 [db-models-transactions]: db-models-transactions.md
 [mvc-url]: mvc-url.md
 [db-layer]: db-layer.md
-[session#bag]: session.md#bag
+[session-bag]: session.md#bag
+[singletons]: https://en.wikipedia.org/wiki/Singleton_pattern

--- a/docs/encryption-crypt.md
+++ b/docs/encryption-crypt.md
@@ -161,7 +161,7 @@ The `encryptBase64()` can be used to encrypt a string in a URL-friendly way. It 
 The `decryptBase64()` can be used to decrypt a string in a URL-friendly way. Similar to `encryptBase64()` it uses `decrypt()` internally and accepts the `text` and optionally the `key` of the element to encrypt. There is also a third parameter `safe` (defaults to `false`) which will perform string replacements for previously replaced non URL _friendly_  characters such as `+` or `/`.
 
 ## Exceptions
-Exceptions thrown in the [Phalcon\Encryption\Crypt][crypt] component will be of type [Phalcon\Encryption\Crypt\Exception][config-exception]. If however, you are using signing and the calculated hash for `decrypt()` does not match, [Phalcon\Encryption\Crypt\Mismatch][crypt-mismatch] will be thrown. You can use these exceptions to selectively catch exceptions thrown only from this component.
+Exceptions thrown in the [Phalcon\Encryption\Crypt][crypt] component will be of type [Phalcon\Encryption\Crypt\Exception][crypt-exception]. If however, you are using signing and the calculated hash for `decrypt()` does not match, [Phalcon\Encryption\Crypt\Mismatch][crypt-mismatch] will be thrown. You can use these exceptions to selectively catch exceptions thrown only from this component.
 
 ```php
 <?php
@@ -190,7 +190,7 @@ The getter `getCipher()` returns the currently selected cipher. If none has been
 You can always get an array of all the available ciphers for your system by calling  `getAvailableCiphers()`.
 
 ### Hash Algorithm
-The getter `getHashAlgo()` returns the hashing algorithm used by the component. If none has been explicitly defined by the setter `setHashAlgo()` the `sha256` will be used. If the hash algorithm defined is not available in the system or is wrong, a [Phalcon\Encryption\Crypt\Exception][crypt=exception] will be thrown.
+The getter `getHashAlgo()` returns the hashing algorithm used by the component. If none has been explicitly defined by the setter `setHashAlgo()` the `sha256` will be used. If the hash algorithm defined is not available in the system or is wrong, a [Phalcon\Encryption\Crypt\Exception][crypt-exception] will be thrown.
 
 You can always get an array of all the available hashing algorithms for your system by calling  `getAvailableHashAlgos()`.
 

--- a/docs/encryption-security-jwt.md
+++ b/docs/encryption-security-jwt.md
@@ -222,7 +222,7 @@ $signer  = new Hmac('sha256');
 $signer  = new Hmac('sha111'); // exception
 ```
 
-The component utilizes the [hmac_equals][hmac_equals] and [hash_hmac][hash_hmac] PHP methods internally to verify and sign the payload. It exposes the following methods:
+The component utilizes the [hash_equals][hash-equals] and [hash_hmac][hash-hmac] PHP methods internally to verify and sign the payload. It exposes the following methods:
 
 ```php
 public function getAlgHeader(): string

--- a/docs/events.md
+++ b/docs/events.md
@@ -965,6 +965,7 @@ The events available in Phalcon are:
 
 [db]: api/phalcon_db.md
 [di-factorydefaul]: api/phalcon_di.md#difactorydefault
+[di-injectable]: api/phalcon_di.md#diinjectable
 [events-event]: api/phalcon_events.md#eventsevent
 [events-eventinterface]: api/phalcon_events.md#eventseventinterface
 [events-eventsawareinterface]: api/phalcon_events.md#eventseventsawareinterface

--- a/docs/filter-filter.md
+++ b/docs/filter-filter.md
@@ -575,6 +575,7 @@ $filteredIp = $locator->sanitize('127.0.0.1', 'ipv4');
 [absint]: https://www.php.net/manual/en/function.absint.php
 [filter]: https://www.php.net/manual/en/book.filter.php
 [filter_var]: https://www.php.net/manual/en/function.filter-var.php
+[htmlspecialchars]: https://www.php.net/manual/en/function.htmlspecialchars.php
 [intval]: https://www.php.net/manual/en/function.intval.php
 [invoke]: https://www.php.net/manual/en/language.oop5.magic.php#object.invoke
 [lcfirst]: https://www.php.net/manual/en/function.lcfirst.php

--- a/docs/flash.md
+++ b/docs/flash.md
@@ -579,3 +579,4 @@ class InvoicesController extends Controller
 [flash-session]: api/phalcon_flash.md#flashsession
 [di-injectable]: api/phalcon_di.md#diinjectable
 [factorydefault]: api/phalcon_di.md#difactorydefault
+[bootstrap]: https://getbootstrap.com/

--- a/docs/html-tagfactory.md
+++ b/docs/html-tagfactory.md
@@ -944,7 +944,7 @@ echo $helper('/my-url', $options);
 ```
 
 ### `inputCheckbox`
-[Phalcon\Html\Helper\Checkbox][html-helper-checkbox] creates a `<input type="checkbox">` tag.
+[Phalcon\Html\Helper\Checkbox][html-helper-input-checkbox] creates a `<input type="checkbox">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -988,7 +988,7 @@ echo $result;
 ```
 
 ### `inputColor`
-[Phalcon\Html\Helper\Color][html-helper-color] creates a `<input type="color">` tag.
+[Phalcon\Html\Helper\Color][html-helper-input-color] creates a `<input type="color">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1019,7 +1019,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputDate`
-[Phalcon\Html\Helper\Date][html-helper-date] creates a `<input type="date">` tag.
+[Phalcon\Html\Helper\Date][html-helper-input-date] creates a `<input type="date">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1050,7 +1050,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputDatetime`
-[Phalcon\Html\Helper\DateTime][html-helper-datetime] creates a `<input type="datetime">` tag.
+[Phalcon\Html\Helper\DateTime][html-helper-input-datetime] creates a `<input type="datetime">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1081,7 +1081,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputDatetimeLocal`
-[Phalcon\Html\Helper\DateTimeLocal][html-helper-datetime-local] creates a `<input type="datetime-local">` tag.
+[Phalcon\Html\Helper\DateTimeLocal][html-helper-input-datetime-local] creates a `<input type="datetime-local">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1112,7 +1112,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputEmail`
-[Phalcon\Html\Helper\Email][html-helper-email] creates a `<input type="email">` tag.
+[Phalcon\Html\Helper\Email][html-helper-input-email] creates a `<input type="email">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1143,7 +1143,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputFile`
-[Phalcon\Html\Helper\File][html-helper-file] creates a `<input type="file">` tag.
+[Phalcon\Html\Helper\File][html-helper-input-file] creates a `<input type="file">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1174,7 +1174,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputHidden`
-[Phalcon\Html\Helper\Hidden][html-helper-hidden] creates a `<input type="hidden">` tag.
+[Phalcon\Html\Helper\Hidden][html-helper-input-hidden] creates a `<input type="hidden">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1205,7 +1205,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputImage`
-[Phalcon\Html\Helper\Image][html-helper-image] creates a `<input type="image">` tag.
+[Phalcon\Html\Helper\Image][html-helper-input-image] creates a `<input type="image">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1236,7 +1236,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputMonth`
-[Phalcon\Html\Helper\Month][html-helper-month] creates a `<input type="month">` tag.
+[Phalcon\Html\Helper\Month][html-helper-input-month] creates a `<input type="month">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1267,7 +1267,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `input`
-[Phalcon\Html\Helper\Input][html-helper-input] creates a `<input>` tag.
+[Phalcon\Html\Helper\Input][html-helper-input-input] creates a `<input>` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1309,7 +1309,7 @@ echo $result;
 ```
 
 ### `inputNumeric`
-[Phalcon\Html\Helper\Numeric][html-helper-numeric] creates a `<input type="numeric">` tag.
+[Phalcon\Html\Helper\Numeric][html-helper-input-numeric] creates a `<input type="numeric">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1340,7 +1340,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputPassword`
-[Phalcon\Html\Helper\Password][html-helper-password] creates a `<input type="password">` tag.
+[Phalcon\Html\Helper\Password][html-helper-input-password] creates a `<input type="password">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1371,7 +1371,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputRadio`
-[Phalcon\Html\Helper\Radio][html-helper-radio] creates a `<input type="radio">` tag.
+[Phalcon\Html\Helper\Radio][html-helper-input-radio] creates a `<input type="radio">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1415,7 +1415,7 @@ echo $result;
 ```
 
 ### `inputRange`
-[Phalcon\Html\Helper\Range][html-helper-range] creates a `<input type="range">` tag.
+[Phalcon\Html\Helper\Range][html-helper-input-range] creates a `<input type="range">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1446,7 +1446,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputSearch`
-[Phalcon\Html\Helper\Search][html-helper-search] creates a `<input type="search">` tag.
+[Phalcon\Html\Helper\Search][html-helper-input-search] creates a `<input type="search">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1477,7 +1477,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputSelect`
-[Phalcon\Html\Helper\Select][html-helper-select] creates a `<select>` tag.
+[Phalcon\Html\Helper\Select][html-helper-input-select] creates a `<select>` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1569,7 +1569,7 @@ echo $result;
 ```
 
 ### `inputSubmit`
-[Phalcon\Html\Helper\Submit][html-helper-submit] creates a `<input type="submit">` tag.
+[Phalcon\Html\Helper\Submit][html-helper-input-submit] creates a `<input type="submit">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1600,7 +1600,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputTel`
-[Phalcon\Html\Helper\Tel][html-helper-tel] creates a `<input type="tel">` tag.
+[Phalcon\Html\Helper\Tel][html-helper-input-tel] creates a `<input type="tel">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1631,7 +1631,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputText`
-[Phalcon\Html\Helper\Text][html-helper-text] creates a `<input type="text">` tag.
+[Phalcon\Html\Helper\Text][html-helper-input-text] creates a `<input type="text">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1662,7 +1662,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputTextarea`
-[Phalcon\Html\Helper\TextArea][html-helper-textarea] creates a `<textarea>` tags
+[Phalcon\Html\Helper\TextArea][html-helper-input-textarea] creates a `<textarea>` tags
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1694,7 +1694,7 @@ echo $helper('click<>me', $options);
 ```
 
 ### `inputTime`
-[Phalcon\Html\Helper\Time][html-helper-time] creates a `<input type="time">` tag.
+[Phalcon\Html\Helper\Time][html-helper-input-time] creates a `<input type="time">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1725,7 +1725,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputUrl`
-[Phalcon\Html\Helper\Url][html-helper-url] creates a `<input type="url">` tag.
+[Phalcon\Html\Helper\Url][html-helper-input-url] creates a `<input type="url">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -1756,7 +1756,7 @@ echo $helper('test-name', "test-value", $options);
 ```
 
 ### `inputWeek`
-[Phalcon\Html\Helper\Week][html-helper-week] creates a `<input type="week">` tag.
+[Phalcon\Html\Helper\Week][html-helper-input-week] creates a `<input type="week">` tag.
 
 | Parameter                | Description                       |
 |--------------------------|-----------------------------------|
@@ -2187,7 +2187,7 @@ echo $result;
 [html-helper-input-color]: api/phalcon_html.md#htmlhelperinputcolor
 [html-helper-input-date]: api/phalcon_html.md#htmlhelperinputdate
 [html-helper-input-datetime]: api/phalcon_html.md#htmlhelperinputdatetime
-[html-helper-input-datetimelocal]: api/phalcon_html.md#htmlhelperinputdatetimelocal
+[html-helper-input-datetime-local]: api/phalcon_html.md#htmlhelperinputdatetimelocal
 [html-helper-input-email]: api/phalcon_html.md#htmlhelperinputemail
 [html-helper-input-file]: api/phalcon_html.md#htmlhelperinputfile
 [html-helper-input-hidden]: api/phalcon_html.md#htmlhelperinputhidden

--- a/docs/logger.md
+++ b/docs/logger.md
@@ -738,6 +738,8 @@ $logger = $container->getShared('logger');
 
 [date-formats]: https://www.php.net/manual/en/function.date.php
 [fifo]: https://en.wikipedia.org/wiki/FIFO_(computing_and_electronics)
+[config]: api/phalcon_config.md/#configconfig
+[factorydefault]: api/phalcon_di.md/#difactorydefault
 [logger-logger]: api/phalcon_logger.md#loggerlogger
 [logger-abstractlogger]: api/phalcon_logger.md#loggerabstractlogger
 [logger-adapter-noop]: api/phalcon_logger.md#loggeradapternoop

--- a/docs/mvc-url.md
+++ b/docs/mvc-url.md
@@ -428,7 +428,7 @@ You can of course access the object the same way as any registered service in th
 
 [url]: api/phalcon_mvc.md#mvcurl
 [url-exception]: api/phalcon_mvc.md#mvcurlexception
-[urlinterface]: api/phalcon_mvc.md#mvcurlurlinterface
+[url-interface]: api/phalcon_mvc.md#mvcurlurlinterface
 [factorydefault]: api/phalcon_di.md#difactorydefault
 [routing]: routing.md
 [di]: di.md

--- a/docs/session.md
+++ b/docs/session.md
@@ -651,3 +651,4 @@ class InvoicesController extends Controller
 [storage-adapter]: api/phalcon_storage.md#storageadapterabstractadapter
 [storage-adapter-libmemcached]: api/phalcon_storage.md#storageadapterlibmemcached
 [storage-adapter-redis]: api/phalcon_storage.md#storageadapterredis
+[incubator]: https://github.com/phalcon/incubator-session

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -544,7 +544,7 @@ $custom->set('my-key', $data);
 ``` 
 
 ## Adapter Factory
-Although all adapter classes can be instantiated using the `new` keyword, Phalcon offers the [Phalcon\Storage\AdapterFactory][cache-adapterfactory] class, so that you can easily instantiate cache adapter classes. All the above adapters are registered in the factory and lazy loaded when called. The factory also allows you to register additional (custom) adapter classes. The only thing to consider is choosing the name of the adapter in comparison to the existing ones. If you define the same name, you will overwrite the built-in one. The objects are cached in the factory so if you call the `newInstance()` method with the same parameters during the same request, you will get the same object back.
+Although all adapter classes can be instantiated using the `new` keyword, Phalcon offers the [Phalcon\Storage\AdapterFactory][storage-adapterfactory] class, so that you can easily instantiate cache adapter classes. All the above adapters are registered in the factory and lazy loaded when called. The factory also allows you to register additional (custom) adapter classes. The only thing to consider is choosing the name of the adapter in comparison to the existing ones. If you define the same name, you will overwrite the built-in one. The objects are cached in the factory so if you call the `newInstance()` method with the same parameters during the same request, you will get the same object back.
 
 The example below shows how you can create an `Apcu` cache adapter with the `new` keyword or the factory:
 ```php
@@ -585,11 +585,11 @@ The parameters you can use for the factory are:
 
 | Name           | Adapter                                                            |
 |----------------|--------------------------------------------------------------------|
-| `apcu`         | [Phalcon\Storage\Adapter\Apcu][cache-adapter-apcu]                 |
-| `libmemcached` | [Phalcon\Storage\Adapter\Libmemcached][cache-adapter-libmemcached] |
-| `memory`       | [Phalcon\Storage\Adapter\Memory][cache-adapter-memory]             |
-| `redis`        | [Phalcon\Storage\Adapter\Redis][cache-adapter-redis]               |
-| `stream`       | [Phalcon\Storage\Adapter\Stream][cache-adapter-stream]             |
+| `apcu`         | [Phalcon\Storage\Adapter\Apcu][storage-adapter-apcu]                 |
+| `libmemcached` | [Phalcon\Storage\Adapter\Libmemcached][storage-adapter-libmemcached] |
+| `memory`       | [Phalcon\Storage\Adapter\Memory][storage-adapter-memory]             |
+| `redis`        | [Phalcon\Storage\Adapter\Redis][storage-adapter-redis]               |
+| `stream`       | [Phalcon\Storage\Adapter\Stream][storage-adapter-stream]             |
 
 ## Events
 

--- a/docs/tag.md
+++ b/docs/tag.md
@@ -1805,3 +1805,4 @@ You can also check out [Volt][volt] a faster template engine for PHP, where you 
 [volt]: volt.md
 [mvc-url]: mvc-url.md
 [forms]: forms.md
+[str_replace]: https://www.php.net/manual/en/function.str-replace.php

--- a/docs/translate.md
+++ b/docs/translate.md
@@ -75,7 +75,7 @@ and for Volt:
 
 ### Placeholders
 
-The `_()` method will return the translated string of the key passed. In the above example, it will return the value stored for the key `hi`. The component can also parse placeholders using [interpolation][#interpolation]. Therefore, for a translation of:
+The `_()` method will return the translated string of the key passed. In the above example, it will return the value stored for the key `hi`. The component can also parse placeholders using [interpolation][interpolation]. Therefore, for a translation of:
 
 ```text
 Hello %name%!
@@ -369,7 +369,7 @@ $translator = $factory->newInstance('csv', $options);
 
 In the above example, you can see the usage of `delimiter` and `enclosure`. In most cases, you will not need to supply these options but in case your CSV files are somewhat different, you have the option to instruct the adapter as to how it will parse the contents of the translation file.
 
-Creating this adapter can be achieved by using the [Translate Factory][translatefactory], but you can instantiate it directly:
+Creating this adapter can be achieved by using the [Translate Factory][translate-factory], but you can instantiate it directly:
 ```php
 <?php
 
@@ -434,7 +434,7 @@ translations/
             translations.po
 ```
 
-Creating this adapter can be achieved by using the [Translate Factory][translatefactory], but you can instantiate it directly:
+Creating this adapter can be achieved by using the [Translate Factory][translate-factory], but you can instantiate it directly:
 ```php
 <?php
 
@@ -643,13 +643,14 @@ $translator = $factory->newInstance(
 [indexedarray]: api/phalcon_translate.md#translateinterpolatorindexedarray
 [interpolatorinterface]: api/phalcon_translate.md#translateinterpolatorinterpolatorinterface
 [interpolatorfactory]: api/phalcon_translate.md#translateinterpolatorfactory
+[interpolation]: api/phalcon_support.md/#supporthelperstrinterpolate
 [nativearray]: api/phalcon_translate.md#translateadapternativearray
 [php-gettext]: https://www.php.net/manual/book.gettext.php
 [poedit]: https://poedit.net/
 [request]: api/phalcon_http.md#httprequest
 [sprintf]: https://www.php.net/manual/en/function.sprintf.php
 [translate]: api/phalcon_translate.md
-[translatefactory]: api/phalcon_translate.md#translatetranslatefactory
+[translate-factory]: api/phalcon_translate.md#translatetranslatefactory
 [wiki-gettext]: https://en.wikipedia.org/wiki/Gettext
 [di]: di.md
 [routing]: routing.md

--- a/docs/tutorial-invo.md
+++ b/docs/tutorial-invo.md
@@ -233,7 +233,7 @@ $di->setShared('db', function () use ($dbConfig) {
 });
 ```
 
-Here, we return an instance of the MySQL connection adapter, because the `$dbConfig['adapter']` setting is `Mysql`. We can also add extra functionality, such as adding a [Logger][logger], a [profiler][db-models-profiler] to measure query execution times or even change the adapter to a different RDBMS.
+Here, we return an instance of the MySQL connection adapter, because the `$dbConfig['adapter']` setting is `Mysql`. We can also add extra functionality, such as adding a [Logger][logger], a profiler to measure query execution times or even change the adapter to a different RDBMS.
 
 The following simple form (`themes/invo/session/index.volt`) produces the necessary HTML so that users can submit login information. Some HTML code has been removed to improve readability:
 
@@ -1733,3 +1733,9 @@ Finally, the title is printed in the main view (`themes/invo/views/index.volt`):
 [dispatcher]: dispatcher.md
 [db-pagination]: db-pagination.md
 [session-persistent-data]: session.md#persistent-data
+[logger]: logger.md
+[events]: events.md
+[acl]: acl.md
+[forms]: forms.md
+[tag]: tag.md
+[request]: request.md

--- a/docs/tutorial-vokuro.md
+++ b/docs/tutorial-vokuro.md
@@ -1538,3 +1538,5 @@ Vökuró is a sample application that we use to demonstrate some of the features
 [db-models-relationships]: db-models-relationships.md
 [events]: events.md
 [encryption-crypt]: encryption-crypt.md
+[request]: request.md
+[db-models]: db-models.md

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -19,7 +19,7 @@ Phalcon can be installed using PECL.
 
 ```
 pecl install phalcon
-// pecl install phalcon-5.9.2
+// pecl install phalcon-5.9.3
 ```
 
 **Alternative installation**
@@ -36,7 +36,7 @@ Compile Phalcon
 
 ```bash
 cd cphalcon/
-git checkout tags/5.9.2 ./
+git checkout tags/5.9.3 ./
 zephir fullclean
 zephir build
 ```
@@ -620,7 +620,7 @@ The [Filter][phalcon-filter-filter] component has been moved to the `Filter` nam
 
 #### `Phalcon\Forms\Element\Check`
 #### `Phalcon\Forms\Element\Radio`
-- The classes now use the `Phalcon\Html\Helper\Input\Checkbox` and `Phalcon\Html\Helper\Input\Radio` respectively. The classes use `checked` and `unchecked` parameters to set the state of each control. If the `checked` parameter is identical to the `$value` then the control will be checked. If the `unchecked` parameter is present, it will be set if the `$value` is not the same as the `checked` parameter. [more][html-tagfactory]
+- The classes now use the `Phalcon\Html\Helper\Input\Checkbox` and `Phalcon\Html\Helper\Input\Radio` respectively. The classes use `checked` and `unchecked` parameters to set the state of each control. If the `checked` parameter is identical to the `$value` then the control will be checked. If the `unchecked` parameter is present, it will be set if the `$value` is not the same as the `checked` parameter. [more][phalcon-html-tagfactory]
 
 ---
 
@@ -672,13 +672,13 @@ The [Helper][phalcon-support-helper] component has been moved to the `Support` n
 
 #### `Phalcon\Html\Helper`
 - Moved `Phalcon\Helper` to `Phalcon\Html\Helper`
-- The component has been refactored and offers more functionality now. [more][html-tagfactory]
+- The component has been refactored and offers more functionality now. [more][phalcon-html-tagfactory]
 
 #### `Phalcon\Html\Link`
-- The component has been refactored and the dependency to `PSR` has been removed. [more][html-link]
+- The component has been refactored and the dependency to `PSR` has been removed. [more][phalcon-html-link]
 
 #### `Phalcon\Html\TagFactory`
-- Added `__call(string $name, array $arguments)` to allow calling helper objects as methods. [more][html-tagfactory]
+- Added `__call(string $name, array $arguments)` to allow calling helper objects as methods. [more][phalcon-html-tagfactory]
 - Added `has(string $name) -> bool`
   Added `set(string $name, mixed $method): void`
 - The `getAdapters()` protected method has been renamed to `getServices()`


### PR DESCRIPTION
I noticed many linkages are broken in many parts of the documentation. I've corrected what I could find, but it is difficult to ensure everything is correct.

Second commit is for the bulk delete callback which I found to not work with one-to-one relations
https://docs.phalcon.io/5.9/db-models-relationships/#delete

Added a warning to point that out.