### PR TITLE
Updated to PHP 8.1 (for Phalcon 5.9)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,9 +4,9 @@
 ## Requirements
 
 ### PHP 8.1
-Phalcon v5.9 supports only PHP 8.0 and above.
+Phalcon v5.9 supports only PHP 8.1 and above.
 
-Although PHP 8.0 was released several years ago and it's [active support][php-support] as well as security updates have expired, Phalcon still supports it, in order to offer enough time for developers to upgrade their applications. We will continue to support PHP 8.0 for v5 for another year. Phalcon v6 and later will support PHP 8.1+.
+Although PHP 8.1 was released several years ago and it's [active support][php-support] as well as security updates have expired, Phalcon still supports it, in order to offer enough time for developers to upgrade their applications.
 
 !!! info "NOTE"
 
@@ -34,7 +34,7 @@ We have hosted our website and blog for the last few years on an Amazon VM with 
 
     You should always try and use the latest version of Phalcon and PHP as both address bugs, security enhancements as well as performance.
 
-Along with PHP 8.0 or greater, depending on your application needs and the Phalcon components you need, you might need to install the following extensions:
+Along with PHP 8.1 or greater, depending on your application needs and the Phalcon components you need, you might need to install the following extensions:
 
 * [curl][curl]
 * [fileinfo][fileinfo]

--- a/docs/testing-environment.md
+++ b/docs/testing-environment.md
@@ -7,7 +7,7 @@ Phalcon, historically characterized by a modest development community and limite
 # The Challenge
 Building a feature-rich framework necessitates a comprehensive development environment supporting various features and associated services. For example, validating ORM functionality across different database adapters (e.g., `MySQL`, `Postgresql`, `Sqlite`) requires the installation of relevant PHP extensions and databases. Similarly, to execute the testing suite for Phalcon's extensive functionality, developers must install numerous extensions and services such as Redis and Memcached.
 
-Considering the diverse PHP versions (e.g., PHP 8.0, 8.1), Phalcon's development becomes intricate due to these prerequisites.
+Considering the diverse PHP versions (e.g., PHP 8.1, 8.2), Phalcon's development becomes intricate due to these prerequisites.
 
 # Solution
 Formerly relying on `nanobox," a solution now discontinued, we intensified our efforts, adopting Docker to streamline development requirements. With just a few commands, developers can seamlessly contribute to Phalcon and execute tests promptly.

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -9,8 +9,8 @@ Phalcon v5 contains a lot of changes in components and interfaces. Upgrading is 
 We will outline the areas that you need to pay attention to and make necessary changes so that your code can run as smoothly as it has been with v4. Although the changes are significant, it is more of a methodical task than a daunting one.
 
 ## Requirements
-### PHP 8.0
-Phalcon v5 supports only PHP 8.0 and above. PHP 8.0 [active support][php-support] has already expired, including security fixes. We will be supporting this version for a while longer, offering developers more time to upgrade their applications.
+### PHP 8.1
+Phalcon v5.9 supports only PHP 8.1 and above. PHP 8.1 [active support][php-support] has already expired, including security fixes. We will be supporting this version for a while longer, offering developers more time to upgrade their applications.
 
 Since Phalcon 4, we have been following the PHP releases and adjusting Phalcon accordingly to work with those releases.
 

--- a/docs/webserver-setup.md
+++ b/docs/webserver-setup.md
@@ -484,7 +484,7 @@ https://example.cc {
     gzip
     tls /ssl/example.cc/cert.pem /ssl/example.cc/key.pem
     root /path/to/phalcon/public
-    fastcgi / unix:/run/php/php8.0-fpm.sock php
+    fastcgi / unix:/run/php/php8.2-fpm.sock php
     rewrite {
         r (.*)
         to {path} {path}/ /index.php?_url={1}


### PR DESCRIPTION
[Since Phalcon 5.9, the minimum PHP version is 8.1](https://github.com/phalcon/cphalcon/blame/7a3b54d8010d7625cefd5adf90fe5546011039d1/composer.json#L25). Some references to the minimum version weren't updated.

I've left some of the tutorial files alone as their Git repos are very out-of-date:

- [Caddy documentation shows PHP 8.2 is used](https://caddyserver.com/docs/caddyfile/directives/root#examples).
- [Vokuro only supports Phalcon 4](https://github.com/phalcon/vokuro/blob/99873e38cda7856779dedde711f453b2e06afc18/composer.json#L30).
- Devilbox seems to be abandoned. As mentioned in this (issue](https://github.com/cytopia/devilbox/issues/1017), an active [fork](https://github.com/devilbox-community/devilbox) has added newer PHP support.