### PR TITLE
Update tutorial-basic.md

### DIFF
--- a/docs/tutorial-basic.md
+++ b/docs/tutorial-basic.md
@@ -77,7 +77,7 @@ To start, let's register our app's `controllers` and `models` directories using 
 
 use Phalcon\Autoload\Loader;
 
-define('BASE_PATH', dirname(__DIR__ . '/..'));
+define('BASE_PATH', dirname(__DIR__));
 define('APP_PATH', BASE_PATH . '/app');
 // ...
 


### PR DESCRIPTION
Remove the parent traversal from the Autoloader code snippet. This is removed in the main example listing further down in the document and is incorrect.