### PR TITLE
Missing parameter in example

### DIFF
--- a/docs/db-layer.md
+++ b/docs/db-layer.md
@@ -318,6 +318,7 @@ $invoice = $connection->fetchColumn(
     'SELECT inv_id, inv_title 
     FROM co_invoices
     ORDER BY inv_created_at DESC',
+    [],
     1
 )
 print_r($invoice)


### PR DESCRIPTION
To demonstrate the use of fetchColumn with parameters, the example misses the second parameter (array for placeholders).